### PR TITLE
SaaStart README.md changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ Use this to bootstrap a SaaS application with the following commonly needed capa
 
 1. Node.js v20 or later is required to run the bootstrapping process. We recommend using [`nvm`](https://github.com/nvm-sh/nvm) to manage node versions in your development environment.
 2. You must have [`npm`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) or a comparable package manager installed in your development environment. These instructions assume that you're using `npm`.
-3. **Create a fresh Auth0 tenant** which will be configured automatically by our bootstrapping command. See [Create Tenants](https://auth0.com/docs/get-started/auth0-overview/create-tenants) in the Auth0 docs if you need help.
+3. **Create a fresh Auth0 tenant** which will be configured automatically by our bootstrapping command. See [Create Tenants](https://auth0.com/docs/get-started/auth0-overview/create-tenants) in the Auth0 docs if you need help. 
 
    Creating a new tenant before you continue is highly recommended so that you don't accidentally change the configuration in any existing Auth0 projects you might have.
+   
+   You can sign up for a free Auth0 account at [https:/auth0.com/signup](https://auth0.com/signup?utm_source=github&utm_medium=thirdpartyutm_campaign=saastart). 
+
 
 ### Step One: Clone and install dependencies
 
@@ -97,7 +100,7 @@ Finally, it will save environment variables for your tenant in the application d
 
 > **Warning**
 >
-> Only run the following command on a newly created tenant to avoid changing existing configuration or introducing conflicting elements to your existing Auth0 tenants! You can sign up for a free tenant at [https:/auth0.com/signup](https://auth0.com/signup?utm_source=github&utm_medium=thirdpartyutm_campaign=saastart). 
+> Only run the following command on a newly created tenant to avoid changing existing configuration or introducing conflicting elements to your existing Auth0 tenants!
 > 
 > If you are creating a new Auth0 tenant at this point in the process, go back to step 2 in order to ensure you're logged into the correct Auth0 tenant.
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ Use this to bootstrap a SaaS application with the following commonly needed capa
 
 1. Node.js v20 or later is required to run the bootstrapping process. We recommend using [`nvm`](https://github.com/nvm-sh/nvm) to manage node versions in your development environment.
 2. You must have [`npm`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) or a comparable package manager installed in your development environment. These instructions assume that you're using `npm`.
-3. **Create a fresh Auth0 tenant** which will be configured automatically by our bootstrapping command. See [Create Tenants](https://auth0.com/docs/get-started/auth0-overview/create-tenants) in the Auth0 docs if you need help. 
+3. Create a new Auth0 tenant which will be configured automatically by our bootstrapping command. You can sign up for a free Auth0 account at [https://auth0.com/signup](https://auth0.com/signup?utm_source=github&utm_medium=thirdpartyutm_campaign=saastart). See [Create Tenants](https://auth0.com/docs/get-started/auth0-overview/create-tenants) in the Auth0 docs if you need help. 
 
    Creating a new tenant before you continue is highly recommended so that you don't accidentally change the configuration in any existing Auth0 projects you might have.
-   
-   You can sign up for a free Auth0 account at [https:/auth0.com/signup](https://auth0.com/signup?utm_source=github&utm_medium=thirdpartyutm_campaign=saastart). 
 
 
 ### Step One: Clone and install dependencies

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# B2B SaaS Starter Kit _from_ Auth0 by Okta
+# **SaaStart** from Auth0 by Okta
 
 A secure and high-performance starting point for building B2B SaaS web applications.
 
@@ -36,24 +36,24 @@ Use this to bootstrap a SaaS application with the following commonly needed capa
 
 ### Prerequisites
 
-1. Node.js v20 or later is required to run the bootstrapping process. We recommend using [`nvm`](https://github.com/nvm-sh/nvm).
+1. Node.js v20 or later is required to run the bootstrapping process. We recommend using [`nvm`](https://github.com/nvm-sh/nvm) to manage node versions in your development environment.
 2. You must have [`npm`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) or a comparable package manager installed in your development environment. These instructions assume that you're using `npm`.
 3. **Create a fresh Auth0 tenant** which will be configured automatically by our bootstrapping command. See [Create Tenants](https://auth0.com/docs/get-started/auth0-overview/create-tenants) in the Auth0 docs if you need help.
 
-   Creating a new tenant before you continue is highly recommended, so that you don't accidentally change the configuration in any existing Auth0 projects you might have.
+   Creating a new tenant before you continue is highly recommended so that you don't accidentally change the configuration in any existing Auth0 projects you might have.
 
 ### Step One: Clone and install dependencies
 
 1. Clone this repo to your development environment
 2. Install dependencies: `npm install`
 
-### Part Two: Install and Log in with the Auth0 CLI
+### Step Two: Install and Log in with the Auth0 CLI
 
 This project uses the Auth0 CLI to make setting up your tenant a lot easier, by scripting away as much manual work as possible. If you want to familiarize yourself with the Auth0 CLI, read [Auth0 CLI Basics](https://developer.auth0.com/resources/labs/tools/auth0-cli-basics).
 
 1. You will need to install the Auth0 CLI. It will be used by the bootstrap script to create the resources needed for this sample in your Auth0 tenant. Instructions for installation are available at the [Auth0 CLI github repo](https://github.com/auth0/auth0-cli).
 
-   **For example**, for users on OSX using , you can run the following command:
+   **For example**, users on OSX using [Homebrew](https://brew.sh/) can run the following command to install the CLI:
 
    ```shell
    brew tap auth0/auth0-cli && brew install auth0
@@ -65,7 +65,7 @@ This project uses the Auth0 CLI to make setting up your tenant a lot easier, by 
    auth0 --version
    ```
 
-   You should see in response the CLI version number printed out, like this:
+   A successful installation will result in a response with the CLI version number printed out, like this:
 
    ```shell
    auth0 version 1.4.0 54e9a30eeb58a4a7e40e04dc19af6869036bfb32
@@ -77,33 +77,35 @@ This project uses the Auth0 CLI to make setting up your tenant a lot easier, by 
    auth0 login --scopes "update:tenant_settings,create:connections,create:client_grants,create:email_templates,update:guardian_factors"
    ```
 
-   Be sure to select **As a user** when prompted: _"How would you like to authenticate?"_. This take you through a flow to securely retrieve a Management API token for your Auth0 tenant.
+   Be sure to select `As a user` when prompted: `How would you like to authenticate?`. This will take you through a flow that will securely retrieve a Management API token for your Auth0 tenant.
 
-   > #### Important
+   > **Warning**
    >
    > At the **Authorize App** step, be sure to select the correct tenant. This is the tenant that will be bootstrapped in the next steps.
 
 ### Step Three: Bootstrap the Auth0 tenant
+
+This step will create and update entities in your Auth0 tenant. The provided script will use the Auth0 CLI to provision the resources required for this sample application:
+
+- Creating the appropriate clients (called Applications in Auth0)
+- Creating admin and member roles,
+- Creating actions for setting roles and security policies
+- Creating email and login templates
+- Enabling MFA factors
+
+Finally, it will save environment variables for your tenant in the application directory.
+
+> **Warning**
+>
+> Only run the following command on a newly created tenant to avoid changing existing configuration or introducing conflicting elements to your existing Auth0 tenants! You can sign up for a free tenant at [https:/auth0.com/signup](https://auth0.com/signup?utm_source=github&utm_medium=thirdpartyutm_campaign=saastart). 
+> 
+> If you are creating a new Auth0 tenant at this point in the process, go back to step 2 in order to ensure you're logged into the correct Auth0 tenant.
 
 Run the following command:
 
 ```shell
 npm run auth0:bootstrap
 ```
-
-> #### Important
->
-> This will create and update entities in your Auth0 tenant – it is best to use afresh/new tenant when bootstrapping. You can sign up for a free tenant at [https:/auth0.com/signup](https://auth0.com/signup?utm_source=github&utm_medium=thirdpartyutm_campaign=saastart).
->
-> Behind the scenes, the bootstrap script in this step will use the Auth0 CLI to provision the resources required for this sample application:
->
-> - Creating the appropriate clients (called Applications in Auth0)
-> - Creating admin and member roles,
-> - Creating actions for setting roles and security policies
-> - Creating email and login templates
-> - Enabling MFA factors
->
-> Finally, it will save environment variables for your tenant in the application directory.
 
 Once the script has successfully completed, a `.env.local` file containing the environment variables will be written to the root of your project directory.
 
@@ -113,10 +115,10 @@ Once the script has successfully completed, a `.env.local` file containing the e
 2. Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
    > Note: If you're running the application on a different port, adjust the provided localhost URL accordingly.
+   
+   You can proceed to interact with the app as if you were a user: create an account, navigate to the settings, explore the identity capabilities.
 
-3. Start editing - for example, modify `app/page.tsx`. The browser will auto-update as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+3. Start editing to build your own SaaS application - for example, modify `app/page.tsx`. The browser will hot-reload to show changes as you edit the file.
 
 ## Learn More
 


### PR DESCRIPTION
In order to align with the new product title SaaStart, I've updated the README.md.

I'm using the opportunity to correct some lingering mistakes, clarify a few steps of instructions, and move the Auth0 Signup link to a more useful position in the Prerequisites section so that users will encounter it /before/ they need it during the CLI login steps.