### PR TITLE
Rename organization references, correct login wording

### DIFF
--- a/app/onboarding/create/actions.ts
+++ b/app/onboarding/create/actions.ts
@@ -5,7 +5,7 @@ import slugify from "@sindresorhus/slugify"
 
 import { managementClient, onboardingClient } from "@/lib/auth0"
 
-export async function createAccount(formData: FormData) {
+export async function createOrganization(formData: FormData) {
   const session = await onboardingClient.getSession()
 
   if (!session) {
@@ -52,9 +52,9 @@ export async function createAccount(formData: FormData) {
       }
     )
   } catch (error) {
-    console.error("failed to create an account", error)
+    console.error("failed to create an organization", error)
     return {
-      error: "Failed to create an account.",
+      error: "Failed to create an organization.",
     }
   }
 

--- a/app/onboarding/create/create-organization-form.tsx
+++ b/app/onboarding/create/create-organization-form.tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Code } from "@/components/code"
 import { SubmitButton } from "@/components/submit-button"
 
-import { createAccount } from "./actions"
+import { createOrganization } from "./actions"
 
 export function CreateOrganizationForm() {
   const { user } = useUser()
@@ -19,12 +19,12 @@ export function CreateOrganizationForm() {
   return (
     <form
       action={async (formData: FormData) => {
-        const { error } = await createAccount(formData)
+        const { error } = await createOrganization(formData)
 
         if (error) {
           toast.error(error)
         } else {
-          toast.success("Your account has been created.")
+          toast.success("Your organization has been created.")
         }
       }}
     >
@@ -58,7 +58,7 @@ export function CreateOrganizationForm() {
             Slug: <Code>{slugify(name || "Acme Corp")}</Code>
           </p>
         </div>
-        <SubmitButton>Create Account</SubmitButton>
+        <SubmitButton>Create Organization</SubmitButton>
       </div>
     </form>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,15 +24,15 @@ export default async function Home() {
           Logout
         </a>
       ) : (
-        <a
+        <div
+          className="absolute right-4 top-4 md:right-8 md:top-8"
+        ><span className="text-sm">Already joined?</span> <a
+          className="text-sm underline"
           href="/api/auth/login"
-          className={cn(
-            buttonVariants({ variant: "link" }),
-            "absolute right-4 top-4 md:right-8 md:top-8"
-          )}
         >
-          Login
+          Log in
         </a>
+        </div>
       )}
 
       <div className="relative hidden h-full flex-col bg-muted p-10 text-white dark:border-r lg:flex">

--- a/app/signup-form.tsx
+++ b/app/signup-form.tsx
@@ -13,7 +13,7 @@ export function SignUpForm() {
           Try SaaStart for Free
         </h1>
         <p className="text-sm text-muted-foreground">
-          Enter your email address to sign up for an account.
+          Enter your email address to sign up and create a new organization for you and your collaborators.
         </p>
       </div>
       <form

--- a/components/organization-switcher.tsx
+++ b/components/organization-switcher.tsx
@@ -28,7 +28,7 @@ import {
 
 type PopoverTriggerProps = React.ComponentPropsWithoutRef<typeof PopoverTrigger>
 
-interface AccountSwitcherProps extends PopoverTriggerProps {
+interface OrganizationSwitcherProps extends PopoverTriggerProps {
   organizations: {
     id: string
     slug: string
@@ -41,7 +41,7 @@ interface AccountSwitcherProps extends PopoverTriggerProps {
 export function OrganizationSwitcher({
   organizations,
   currentOrgId,
-}: AccountSwitcherProps) {
+}: OrganizationSwitcherProps) {
   const [open, setOpen] = useState(false)
   const router = useRouter()
 


### PR DESCRIPTION
### Primary change:
I've tried to rename any actions or UI references to Organizations which might have been labelled as Account instead. Please review these changes and let me know if I've made any mistakes.


### Minor fix: 
Previously we had 'Login' floating in the top right of the sign in page. I'm proposing we change this to 'Log in' and add a bit of a hint and styling change to make the element more visible and understandable to users:

**Before:**
![image](https://github.com/auth0-developer-hub/auth0-b2b-saas-starter/assets/6372810/23fb843b-9e81-47ca-9eea-3d97c6ee8507)

**After:**
![image](https://github.com/auth0-developer-hub/auth0-b2b-saas-starter/assets/6372810/e553fe9d-68fa-4804-a88e-56dd0e1fb45a)
