### PR TITLE
fix: secondary colors contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,8 +16,8 @@
     --primary: 0 0% 9%;
     --primary-foreground: 0 0% 98%;
 
-    --secondary: 0 0% 96%;
-    --secondary-foreground: 0 0% 56%;
+    --secondary: 240 6% 90%;
+    --secondary-foreground: 0 0% 9%;
 
     --muted: 240 6% 90%;
     --muted-foreground: 0 0% 40%;
@@ -51,8 +51,8 @@
     --primary: 0 0% 98%;
     --primary-foreground: 0 0% 9%;
 
-    --secondary: 0 0% 16%;
-    --secondary-foreground: 0 0% 56%;
+    --secondary: 240 6% 20%;
+    --secondary-foreground: 0 0% 98%;
 
     --muted: 240 6% 20%;
     --muted-foreground: 0 0% 56%;


### PR DESCRIPTION
Previously the secondary colors made buttons look disabled and badges washed out.

![CleanShot 2024-07-23 at 15 18 46](https://github.com/user-attachments/assets/343ba9fa-9916-4141-9e1b-8269298d939b)

![CleanShot 2024-07-23 at 15 18 35](https://github.com/user-attachments/assets/f4a7ab5d-e1ed-40c0-93ad-f47f15aa7679)
