### PR TITLE
Remove note about authenticating as user from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ This project uses the Auth0 CLI to make setting up your tenant a lot easier, by 
    auth0 login --scopes "update:tenant_settings,create:connections,create:client_grants,create:email_templates,update:guardian_factors"
    ```
 
-   Be sure to select `As a user` when prompted: `How would you like to authenticate?`. This will take you through a flow that will securely retrieve a Management API token for your Auth0 tenant.
-
    > **Warning**
    >
    > At the **Authorize App** step, be sure to select the correct tenant. This is the tenant that will be bootstrapped in the next steps.

--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ This project uses the Auth0 CLI to make setting up your tenant a lot easier, by 
    auth0 login --scopes "update:tenant_settings,create:connections,create:client_grants,create:email_templates,update:guardian_factors"
    ```
 
-   > **Warning**
-   >
-   > At the **Authorize App** step, be sure to select the correct tenant. This is the tenant that will be bootstrapped in the next steps.
+   This will take you through a flow that will securely retrieve a Management API token for your Auth0 tenant.
+
+> [!WARNING]
+> At the **Authorize App** step, be sure to select the correct tenant. This is the tenant that will be bootstrapped in the next steps.
 
 ### Step Three: Bootstrap the Auth0 tenant
 


### PR DESCRIPTION
We have a vestigial reference to authenticating *as a user* vs *as a machine* in regard to a prompt that the Auth0 CLI presents the user with when a user uses an `auth0 login` command. However, this doesn't happen when we use the `--scopes` flag that is in our README.md instructions. This PR removes the reference that might confuse users who are asked to make sure they authenticate as a user, but are never prompted to do so in their terminal.