### PR TITLE
Add prompt and checks during bootstrap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ Run the following command:
 npm run auth0:bootstrap
 ```
 
+The script will prompt you to provide an **application base URL**, which defaults to http://localhost:3000. If you're configuring the application to run with HTTPS or on a production URL, this is your opportunity to set it. One reason to take note of this is that organization invites sent to emails will NOT work by default if you use localhost. Learn more about this in [README-ADVANCED.md](README-ADVANCED.md).
+> [!TIP]
+> If you want to skip this prompt you can run the bootstrapping command with an argument:
+> ```bash
+> npm run auth0:bootstrap -- allowLocalhost
+> ```
+
 Once the script has successfully completed, a `.env.local` file containing the environment variables will be written to the root of your project directory.
 
 ### Step Four: Run the sample application


### PR DESCRIPTION
This is a test to see whether we can add a live prompt to the bootstrap script where we ask the user what they want to use for their base URL. Doing so avoids the previous approach of erroring out and forcing them to add a flag in order to run the default localhost pattern.

Screenshot:
![image](https://github.com/user-attachments/assets/0851e06f-6945-4bf8-bc6f-55ac17226371)